### PR TITLE
Ux issue 098 automate quotes

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,4 +1,4 @@
-name: daily_quotes
+name: daily
 
 on:
   workflow_dispatch:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -16,41 +16,44 @@ jobs:
       - name: Checkout pivoteur.github.io
         uses: actions/checkout@v4
 
+      - name: Checkout protocol
+        uses: actions/checkout@v4
+        with:
+          repository: pivoteur/protocol
+          path: protocol
+
       - name: Checkout crypto-n-rust
         uses: actions/checkout@v4
         with:
           repository: logicalgraphs/crypto-n-rust
           path: crypto-n-rust
 
-      - name: Grab latest quotes line and convert to JSON
+      - name: Cache quotes binary
+        id: quotes-cache
+        uses: actions/cache@v3
+        with:
+          path: protocol/dapps/quotes/target/release/quotes
+          key: quotes-binary-${{ hashFiles('protocol/quizzes/src/quiz10/d_quotes/**/*.rs', 'protocol/dapps/quotes/Cargo.toml', 'protocol/dapps/quotes/Cargo.lock') }}
+
+      - name: Install Rust toolchain
+        if: steps.quotes-cache.outputs.cache-hit != 'true'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Build quotes
+        if: steps.quotes-cache.outputs.cache-hit != 'true'
         run: |
-          QUOTES_CSV="crypto-n-rust/data-files/csv/quotes.csv"
+          cargo build --manifest-path protocol/dapps/quotes/Cargo.toml \
+            --bin quotes --release
 
-          # Row 1: coingecko IDs (skip)
-          # Row 2: ticker symbols (use as keys)
-          # Last row: most recent date's prices
-          HEADERS=$(sed -n '2p' "$QUOTES_CSV")
-          LATEST=$(tail -n 1 "$QUOTES_CSV")
+      - name: Add quotes and date to PATH
+        run: |
+          echo "$GITHUB_WORKSPACE/protocol/dapps/quotes/target/release" >> $GITHUB_PATH
+          echo "LE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-          python3 - <<EOF
-          import csv, json
-
-          headers = "$HEADERS".split(',')
-          values  = "$LATEST".split(',')
-
-          row = dict(zip(headers, values))
-
-          # promote date to top-level, cast everything else to float
-          date = row.pop('date')
-          prices = {k: float(v) for k, v in row.items()}
-
-          output = {"date": date, **prices}
-
-          with open("data/quotes.json", "w") as f:
-              json.dump(output, f, indent=2)
-
-          print(f"Wrote quotes.json for {date}")
-          EOF
+      - name: Run quotes
+        run: quotes > libs/quotes.json
 
       - name: Commit and push quotes.json
         env:
@@ -59,7 +62,7 @@ jobs:
         run: |
           git config --local user.email "$USER0_EMAIL"
           git config --local user.name "$USER0_NAME"
-          git add data/quotes.json
-          git commit -m "Daily quotes JSON for $(tail -n 1 crypto-n-rust/data-files/csv/quotes.csv | cut -d',' -f1)"
+          git add libs/quotes.json
+          git commit -m "Daily quotes JSON for $LE_DATE"
           git push
           

--- a/.github/workflows/daily_quotes.yml
+++ b/.github/workflows/daily_quotes.yml
@@ -1,0 +1,65 @@
+name: daily_quotes
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   # runs 1 hour after quotes.yml (02:37 UTC) in crypto-n-rust
+  #   - cron: "37 03 * * *"
+
+permissions:
+  contents: write
+
+jobs:
+  quotes-to-json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pivoteur.github.io
+        uses: actions/checkout@v4
+
+      - name: Checkout crypto-n-rust
+        uses: actions/checkout@v4
+        with:
+          repository: logicalgraphs/crypto-n-rust
+          path: crypto-n-rust
+
+      - name: Grab latest quotes line and convert to JSON
+        run: |
+          QUOTES_CSV="crypto-n-rust/data-files/csv/quotes.csv"
+
+          # Row 1: coingecko IDs (skip)
+          # Row 2: ticker symbols (use as keys)
+          # Last row: most recent date's prices
+          HEADERS=$(sed -n '2p' "$QUOTES_CSV")
+          LATEST=$(tail -n 1 "$QUOTES_CSV")
+
+          python3 - <<EOF
+          import csv, json
+
+          headers = "$HEADERS".split(',')
+          values  = "$LATEST".split(',')
+
+          row = dict(zip(headers, values))
+
+          # promote date to top-level, cast everything else to float
+          date = row.pop('date')
+          prices = {k: float(v) for k, v in row.items()}
+
+          output = {"date": date, **prices}
+
+          with open("data/quotes.json", "w") as f:
+              json.dump(output, f, indent=2)
+
+          print(f"Wrote quotes.json for {date}")
+          EOF
+
+      - name: Commit and push quotes.json
+        env:
+          USER0_NAME: ${{ vars.USER0_NAME }}
+          USER0_EMAIL: ${{ secrets.USER0_EMAIL }}
+        run: |
+          git config --local user.email "$USER0_EMAIL"
+          git config --local user.name "$USER0_NAME"
+          git add data/quotes.json
+          git commit -m "Daily quotes JSON for $(tail -n 1 crypto-n-rust/data-files/csv/quotes.csv | cut -d',' -f1)"
+          git push
+          


### PR DESCRIPTION
### I fixed `daily.yml`; now, the run is a clean: `quotes > libs/quotes.json` 
* With a cache upgrade. 

## Apparently:

> " _The checkout steps always run regardless — they're not gated — because the workspace still needs to be populated to read/write files._ "  -_Claus_ 

Is this true?